### PR TITLE
fix unrounded value for toggle strip and bus actions

### DIFF
--- a/extension.yml
+++ b/extension.yml
@@ -1,6 +1,6 @@
 name: Voicemeeter Control
 package: voicemeeter-control
-version: 1.5.0
+version: 1.5.1
 description: Control Voicemeeter through Deckboard
 author: Riva Farabi, Benjamin Kahlau
 license: MIT

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ class VoicemeeterControl extends Extension {
 					this.vm.setStripParameter(
 						number,
 						param,
-						this.vm.getStripParameter(number, param) === 0 ? 1 : 0
+						Math.round(this.vm.getStripParameter(number, param)) === 0 ? 1 : 0
 					);
 					break;
 				case 'vm-increase-strip':
@@ -113,7 +113,7 @@ class VoicemeeterControl extends Extension {
 					this.vm.setBusParameter(
 						number,
 						param,
-						this.vm.getBusParameter(number, param) === 0 ? 1 : 0
+						Math.round(this.vm.getBusParameter(number, param)) === 0 ? 1 : 0
 					);
 					break;
 				case 'vm-increase-bus':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voicemeeter-control",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Control Voicemeeter through Deckboard",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix "Toggle Strip Parameter" and "Toggle Bus Parameter" actions mentioned in #16 and #17

Issue caused by `this.vm.getStripParameter(number, param))` and `this.vm.getBusParameter(number, param))` that always return `0.000`, not a rounded number `0`, causing it passed `0` as value for `setStripParameter` and `setBusParameter` parameter